### PR TITLE
0.2.0 -> 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ intervene.key-handler.keys.uri=/key/{secretId}/version/{secretIdVersion}
 
 See the [file handler CLI](https://github.com/ebi-gdp/globus-file-handler-cli) README for a description of the configuration. 
 
+`--key` can be a crypt4gh private key path or a JSON file with the following structure:
+
+```
+{
+  "secretId": "8D705854-9EEA-44C5-9937-E4E5228B8457",
+  "secretIdVersion": "1"
+}
+```
+
+which integrates with the key handler service.
+
 ## Example use cases
 
 ### Downloading files with crypt4gh decryption on the fly

--- a/main.nf
+++ b/main.nf
@@ -17,10 +17,10 @@ if (!params.secret_key) {
 process download_decrypt {
     maxForks params.threads
     tag "${in_map.filename}"
-    publishDir "$params.outdir"
+    publishDir "$params.outdir", mode: "move"
     container "${ workflow.containerEngine == 'singularity' ?
-        "oras://ghcr.io/ebi-gdp/globus-file-handler-cli:1.0.3-singularity" :
-        "ghcr.io/ebi-gdp/globus-file-handler-cli:1.0.3" }"
+        "oras://ghcr.io/ebi-gdp/globus-file-handler-cli:1.0.4-singularity" :
+        "ghcr.io/ebi-gdp/globus-file-handler-cli:1.0.4" }"
 
     input:
     val in_map
@@ -32,7 +32,7 @@ process download_decrypt {
 
     script:
     """
-    java -jar /opt/globus-file-handler-cli-1.0.3.jar \
+    java -jar /opt/globus-file-handler-cli-1.0.4.jar \
       --spring.config.location=./secret.properties \
       --globus_file_transfer_source_path "globus:///${in_map.dir_path_on_guest_collection}/${in_map.filename}" \
       --globus_file_transfer_destination_path "file:///\$PWD/${file(in_map.filename).baseName}" \

--- a/main.nf
+++ b/main.nf
@@ -10,84 +10,47 @@ if (!params.input) {
   error "Error: missing mandatory parameter --input"
 }
 
+if (!params.secret_key) {
+  error "Error: missing --secret_key"
+}
 
 process download_decrypt {
-    errorStrategy { sleep(Math.pow(2, task.attempt) * 200 as long); return 'retry' }
     maxForks params.threads
     tag "${in_map.filename}"
-    publishDir "$params.outdir", mode: "move"
+    publishDir "$params.outdir"
     container "${ workflow.containerEngine == 'singularity' ?
-        "oras://ghcr.io/ebi-gdp/globus-file-handler-cli:1.0.0-singularity" :
-        "ghcr.io/ebi-gdp/globus-file-handler-cli:1.0.0" }"
+        "oras://ghcr.io/ebi-gdp/globus-file-handler-cli:1.0.3-singularity" :
+        "ghcr.io/ebi-gdp/globus-file-handler-cli:1.0.3" }"
 
     input:
-    val in_map 
-    path config_path
-    path secret_path
-    path secret_key
+    val in_map
+    path secret_config, stageAs: "secret.properties"
+    path secret_key, stageAs: "secret-config.json"
 
     output:
     path "${file(in_map.filename).baseName}"
 
-    when:
-    in_map.filename.endsWith(".crypt4gh") && secret_key.name != "NO_FILE"
-  
     script:
     """
-    java -jar /opt/globus-file-handler-cli-1.0.0.jar \
-      -Dspring.config.location=${config_path},${secret_path} \
-      -s "${in_map.dir_path_on_guest_collection}/${in_map.filename}" \
-      -d "\$PWD/${file(in_map.filename).baseName}" \
-      -l ${in_map.size} \
+    java -jar /opt/globus-file-handler-cli-1.0.3.jar \
+      --spring.config.location=./secret.properties \
+      --globus_file_transfer_source_path "globus:///${in_map.dir_path_on_guest_collection}/${in_map.filename}" \
+      --globus_file_transfer_destination_path "file:///\$PWD/${file(in_map.filename).baseName}" \
+      --file_size ${in_map.size} \
       --crypt4gh \
-      --sk ${secret_key}
-    """      
-}
-
-process download {
-    errorStrategy { sleep(Math.pow(2, task.attempt) * 200 as long); return 'retry' }
-    maxForks params.threads
-    tag "${in_map.filename}"
-    publishDir "$params.outdir", mode: "move"
-    container "${ workflow.containerEngine == 'singularity' ?
-        "oras://ghcr.io/ebi-gdp/globus-file-handler-cli:1.0.0-singularity" :
-        "ghcr.io/ebi-gdp/globus-file-handler-cli:1.0.0" }"
-
-    input:
-    val in_map 
-    path config_path
-    path secret_path
-    path secret_key
-
-    output:
-    path "${in_map.filename}"
-
-    when:
-    !in_map.filename.endsWith(".crypt4gh") || secret_key.name == "NO_FILE"
-  
-    script:
-    """
-    java -jar /opt/globus-file-handler-cli-1.0.0.jar \
-      -Dspring.config.location=${config_path},${secret_path} \
-      -s "${in_map.dir_path_on_guest_collection}/${in_map.filename}" \
-      -d "\$PWD/${in_map.filename}" \
-      -l ${in_map.size}
+      --sk "file:///\$PWD/secret-config.json"
     """
 }
 
 workflow {
     // using first() to create reusable value channels
     Channel.fromPath(params.secret_key, checkIfExists: true).first().set { secret_key }
-    Channel.fromPath(params.config_path, checkIfExists: true).first().set { config_path }
-    Channel.fromPath(params.config_secrets, checkIfExists: true).first().set { secrets_path }
+    Channel.fromPath(params.config_secrets, checkIfExists: true).first().set { secrets_config_path }
 
     // this channel is a list of hashmaps, one for each file to be downloaded
     Channel.fromPath(params.input, checkIfExists: true).map { parseInput(it) }.flatten().set { ch_input }
 
-    // decryption on the fly will automatically happen if a filename ends with .crypt4gh and a --key is provided
-    download_decrypt(ch_input, config_path, secrets_path, secret_key)
-    // if --key is missing or a file doesn't end with .crypt4gh, just download
-    download(ch_input, config_path, secrets_path, secret_key)
+    download_decrypt(ch_input, secrets_config_path, secret_key)
 }
 
 
@@ -95,7 +58,7 @@ def parseInput(json_file) {
     slurp = new JsonSlurper()
     def slurped = slurp.parseText(json_file.text)
     def meta = slurped.subMap("dir_path_on_guest_collection")
-    def parsed = slurped.files.collect { meta + it } 
+    def parsed = slurped.files.collect { meta + it }
 
     return parsed
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,7 +4,6 @@ params {
     input = null
 
     // optional params
-    threads = 1
     outdir = "results"
 }
 
@@ -37,8 +36,8 @@ manifest {
     author          = 'Benjamin Wingfield'
     defaultBranch   = 'main'
     homePage        = 'https://github.com/ebi-gdp/globflow'
-    description     = 'Download files from Globus over HTTPS, with optional decryption on the fly'
+    description     = 'Download files from Globus over HTTPS, with decryption on the fly'
     mainScript      = 'main.nf'
     nextflowVersion = '>=23.10.1'
-    version         = '0.2.0'
+    version         = '1.0.0'
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,9 +5,7 @@ params {
 
     // optional params
     threads = 1
-    config_path = "$baseDir/assets/application-dev.properties"
     outdir = "results"
-    secret_key = "$baseDir/assets/NO_FILE"
 }
 
 profiles {
@@ -16,7 +14,7 @@ profiles {
         singularity.enabled = false
     }
     arm {
-        docker.runOptions      = '--platform=linux/arm64'
+        docker.runOptions  = '--platform=linux/arm64'
     }
     singularity {
         singularity.enabled = true


### PR DESCRIPTION
## Changelog

* Bump globus-file-handler-cli to `1.0.4`
* Support integration with key handler service
* Clean up temporary files after transfer
* **Breaking change**: drop download only support - all transfers must be decrypted on the fly 